### PR TITLE
Fixes + docker-compose

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -111,7 +111,6 @@ defaults: &defaults
           pip install Pygments
           grep -q $VERSION notebooker/_version.py || (echo "ERROR: Version number not found in notebooker/_version.py: $VERSION"; exit 1)
           grep -q $VERSION CHANGELOG.md || (echo "ERROR: Version number not found in CHANGES.md: $VERSION"; exit 1)
-          grep -q $VERSION docker/Dockerfile || (echo "ERROR: Version number not found in docker/Dockerfile: $VERSION"; exit 1)
           grep -q $VERSION docs/conf.py || (echo "ERROR: Version number not found in docs/source/conf.py: $VERSION"; exit 1)
           grep -q $VERSION notebooker/web/static/package.json || (echo "ERROR: Version number not found in package.json: $VERSION"; exit 1)
           python setup.py --long-description > ../README.rst

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,4 @@
+include CHANGELOG.md
 recursive-include notebooker/web/templates *
 recursive-include notebooker/web/static *
+recursive-include notebooker *.tpl

--- a/README.md
+++ b/README.md
@@ -22,6 +22,13 @@ See the documentation at [https://notebooker.readthedocs.io/](https://notebooker
 
 Notebooker has been tested on Linux, Windows 10, and OSX; the webapp has been tested on Google Chrome.
 
+If you want to explore an example right away, you can use docker-compose:
+```sh
+cd docker
+docker-compose up
+```
+That will expose Notebooker at http://localhost:8080/ with the example templates.
+
 # Contributors
 Notebooker has been actively maintained at Man Group since late 2018, with the original concept built by 
 [Jon Bannister](https://github.com/jonbannister). 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -12,37 +12,46 @@ RUN set -eux \
   ; yarn run lint \
   ; ls -lah node_modules
 
-FROM continuumio/anaconda3:latest as python_build
+
+FROM continuumio/anaconda3:2020.07-alpine as python_build
+
+# this is needed for the a mongodb test fixture
+USER root
+RUN set -eux \
+  ; echo 'http://dl-cdn.alpinelinux.org/alpine/v3.9/community' >> /etc/apk/repositories \
+  ; echo 'http://dl-cdn.alpinelinux.org/alpine/v3.9/main' >> /etc/apk/repositories \
+  ; apk update \
+  ; apk add mongodb=4.0.5-r0 git
 
 COPY --from=node_build /workspace /workspace
 
 ENV PATH="/opt/conda/bin/:${PATH}"
 
 WORKDIR /workspace
+
 RUN set -eux \
-  ; pip install -e ".[prometheus]" ".[test]" \
+  ; pip install -e ".[prometheus, test, docs]" \
   ; python -m ipykernel install --user --name=notebooker_kernel \
   ; pip install -r ./notebooker/notebook_templates_example/notebook_requirements.txt \
   ; python setup.py develop \
   ; python setup.py build_sphinx \
   ; py.test tests \
-  ; python setup.py bdist_egg
+  ; python setup.py bdist_wheel --universal
 
-FROM continuumio/anaconda3:latest
 
-COPY --from=python_build /workspace/dist/*.egg /app/
+FROM continuumio/anaconda3:2020.07-alpine
+USER root
+# FIXME: more is needed to generate PDFs: latest error is `LaTeX Error: File `tcolorbox.sty' not found.`
+RUN apk add git texlive-xetex
+USER anaconda
 
 WORKDIR /app
-ENV VERSION=0.0.1
 
-RUN echo 'http://dl-cdn.alpinelinux.org/alpine/v3.9/community' >> /etc/apk/repositories
-RUN echo 'http://dl-cdn.alpinelinux.org/alpine/v3.9/main' >> /etc/apk/repositories
-RUN apk update
-RUN apk add mongodb=4.0.5-r0
+COPY ./notebooker/notebook_templates_example/notebook_requirements.txt ./
+COPY --from=python_build /workspace/dist/*.whl /app/
 
-RUN python -m ipykernel install --user --name=notebooker_kernel
-RUN pip install -r ./notebook_templates/notebook_requirements.txt
+ENV PATH="/opt/conda/bin/:${PATH}"
 
 RUN set -eux \
-  ; . /root/.bashrc \
-  ; pip install "notebooker-${VERSION}-py3.6.egg"
+  ; python -m ipykernel install --user --name=notebooker_kernel \
+  ; pip install -r ./notebook_requirements.txt ./notebooker-*.whl

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -1,0 +1,60 @@
+version: "3"
+
+services:
+  # note:
+  #  * the templates' required python modules must be baked into the image
+  notebooker:
+    build:
+      context: ..
+      dockerfile: docker/Dockerfile
+    environment:
+      # config variables are defined in notebooker/web/config/setting.py
+      PORT: 11828
+      LOGGING_LEVEL: info
+
+      MONGO_USER: root
+      MONGO_PASSWORD: toor
+      MONGO_HOST: mongodb:27017
+      # this should be something like "notebooker" but this simplifies the compose file
+      DATABASE_NAME: admin
+      RESULT_COLLECTION_NAME: notebook_results
+
+      PY_TEMPLATE_DIR: /var/run/template_repo
+    volumes:
+      - git-repo:/var/run/template_repo
+    command: ["notebooker_webapp"]
+    ports:
+      - 8080:11828
+    depends_on:
+      - mongodb
+    restart: always
+
+  # populate the volume where the git-repo resides with the example
+  git-repo-init:
+    build:
+      context: ..
+      dockerfile: docker/Dockerfile
+    volumes:
+      - git-repo:/var/run/template_repo
+    entrypoint: ["/bin/sh", "-c"]
+    user: root
+    command:
+      - |
+        set -o errexit -o nounset -o pipefail
+        # needed for the git init
+        git config --global user.email "example@example.com"
+        git config --global user.name "Example Name"
+        cd /var/run/template_repo
+        cp -R /opt/conda/lib/python3.8/site-packages/notebooker/notebook_templates_example/ ./
+        git init .
+        git add .
+        git commit -m "Initial commit"
+
+  mongodb:
+    image: mongo:4.4.1-bionic
+    environment:
+      MONGO_INITDB_ROOT_USERNAME: root
+      MONGO_INITDB_ROOT_PASSWORD: toor
+
+volumes:
+  git-repo:

--- a/docs/setup.rst
+++ b/docs/setup.rst
@@ -59,13 +59,13 @@ Install Notebooker
 
 .. code:: bash
 
-    $ pip install -r notebook_templates/notebook_requirements.txt
+    $ pip install -r notebooker/notebook_templates_example/notebook_requirements.txt
 
 5. Run the webapp!
 
 .. code:: bash
 
-    $ MONGO_USER=jon MONGO_PASSWORD=hello PORT=11828 notebooker_webapp
+    $ MONGO_HOST=localhost:27017 MONGO_USER=jon MONGO_PASSWORD=hello PORT=11828 notebooker_webapp
 
 6. Open the link that is printed in your web browser.
 

--- a/docs/setup.rst
+++ b/docs/setup.rst
@@ -1,11 +1,18 @@
 .. _Initial Setup:
 
-Getting Started
-===============
+Docker
+======
+
+The docker-compose setup in the docker directory will bring up a demo instance which is exposed
+on your port 8080 of your local machine. It can be used as a reference for your own setups.
+
+
+Manual Installation
+===================
 
 Prerequisites
 -------------
-* python 3.6+ (2.7 may work, but is not actively supported)
+* python 3.6+
 * `mongodb <https://www.mongodb.com/download-center/community?jmp=docs>`_ >= 2.4.x
 * npm
 

--- a/notebooker/execute_notebook.py
+++ b/notebooker/execute_notebook.py
@@ -338,10 +338,19 @@ def main(
         raise ValueError("Error! Please provide a --report-name.")
     mongo_db_name = mongo_db_name or os.environ.get("DATABASE_NAME", "notebooker")
     mongo_host = mongo_host or os.environ.get("MONGO_HOST", "research")
-    mongo_user = mongo_user or os.environ.get("MONGO_USER", "research")
-    os.environ["MONGO_USER"] = mongo_user
-    mongo_password = mongo_password or os.environ.get("MONGO_PASSWORD", "research")
-    os.environ["MONGO_PASSWORD"] = mongo_password  # FIXME: rather insecure..
+
+    mongo_user = mongo_user if mongo_user is not None else os.environ.get("MONGO_USER")
+    if mongo_user is None:
+        os.environ.pop("MONGO_USER", None)
+    else:
+        os.environ["MONGO_USER"] = mongo_user
+
+    mongo_password = mongo_password if mongo_password is not None else os.environ.get("MONGO_PASSWORD")
+    if mongo_password is None:
+        os.environ.pop("MONGO_PASSWORD", None)
+    else:
+        os.environ["MONGO_PASSWORD"] = mongo_password  # FIXME: rather insecure..
+
     result_collection_name = result_collection_name or os.environ.get("RESULT_COLLECTION_NAME", "NOTEBOOK_OUTPUT")
     if notebook_kernel_name:
         os.environ["NOTEBOOK_KERNEL_NAME"] = notebook_kernel_name
@@ -374,6 +383,8 @@ def main(
         database_name=mongo_db_name,
         mongo_host=mongo_host,
         result_collection_name=result_collection_name,
+        user=mongo_user,
+        password=mongo_password,
     )
     results = []
     for overrides in all_overrides:

--- a/notebooker/web/routes/run_report.py
+++ b/notebooker/web/routes/run_report.py
@@ -154,6 +154,17 @@ def run_report(report_name, report_title, mailto, overrides, generate_pdf_output
             result_serializer.database_name,
             "--mongo-host",
             result_serializer.mongo_host,
+
+            *(
+                ("--mongo-user", result_serializer.user)
+                if result_serializer.user is not None else
+                ()
+            ),
+            *(
+                ("--mongo-password", result_serializer.password)
+                if result_serializer.password is not None else
+                ()
+            ),
             "--result-collection-name",
             result_serializer.result_collection_name,
             "--pdf-output" if generate_pdf_output else "--no-pdf-output",

--- a/setup.py
+++ b/setup.py
@@ -45,6 +45,7 @@ setup(
     license="AGPLv3",
     url="https://github.com/man-group/notebooker",
     packages=find_packages(exclude=["tests", "tests.*", "benchmarks"]),
+    package_data={'': ["CHANGELOG.md", "**/*.tpl"]},
     setup_requires=["six", "numpy"],
     python_requires=">=3.5",
     zip_safe=False,

--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,6 @@ setup(
     license="AGPLv3",
     url="https://github.com/man-group/notebooker",
     packages=find_packages(exclude=["tests", "tests.*", "benchmarks"]),
-    package_data={'': ["CHANGELOG.md", "**/*.tpl"]},
     setup_requires=["six", "numpy"],
     python_requires=">=3.5",
     zip_safe=False,

--- a/tests/integration/test_handle_overrides.py
+++ b/tests/integration/test_handle_overrides.py
@@ -1,5 +1,6 @@
 import datetime
 import re
+import sys
 
 import pytest
 from six import PY2
@@ -34,7 +35,10 @@ VARIABLE_ASSIGNMENT_REGEX = re.compile("^(?P<variable_name>[a-zA-Z_]+) *= *(?P<v
                 "execute the notebook with it! (Error: {})".format(
                     "datetime.datetime(2018, 1, 1, 0, 0) is not JSON serializable, Value: 2018-01-01 00:00:00"
                     if PY2
-                    else "Object of type 'datetime' is not JSON serializable, Value: 2018-01-01 00:00:00"
+                    else
+                    "Object of type 'datetime' is not JSON serializable, Value: 2018-01-01 00:00:00"
+                    if sys.version_info < (3, 7)
+                    else "Object of type datetime is not JSON serializable, Value: 2018-01-01 00:00:00"
                 )
             ],
         ),
@@ -67,9 +71,5 @@ VARIABLE_ASSIGNMENT_REGEX = re.compile("^(?P<variable_name>[a-zA-Z_]+) *= *(?P<v
 def test_handle_overrides_normal(test_name, input_str, expected_output_values, expected_issues):
     issues = []
     override_dict = handle_overrides(input_str, issues)
-    if sorted(issues) != sorted(expected_issues) and expected_issues:
-        for expected_issue in expected_issues:
-            fail_msg = "Issue {} was not found in the list of issues: {}".format(expected_issue, issues)
-            assert any(expected_issue in issue for issue in issues), fail_msg
     assert sorted(issues) == sorted(expected_issues)
     assert sorted(override_dict.items()) == sorted(expected_output_values.items())

--- a/tests/unit/test_handle_overrides.py
+++ b/tests/unit/test_handle_overrides.py
@@ -2,6 +2,7 @@ from __future__ import unicode_literals
 
 import datetime
 import re
+import sys
 from typing import Any
 
 import freezegun
@@ -93,10 +94,12 @@ def test_handle_overrides_handles_imports_with_issues(input_txt):
         issues = []
         overrides = handle_overrides(input_txt, issues)
     assert overrides == {}
-    if PY3:
+    if PY2:
+        error_string = "datetime.datetime(10, 1, 1, 0, 0) is not JSON serializable, Value: 0010-01-01 00:00:00"
+    elif sys.version_info < (3, 7):
         error_string = "Object of type 'datetime' is not JSON serializable, Value: 0010-01-01 00:00:00"
     else:
-        error_string = "datetime.datetime(10, 1, 1, 0, 0) is not JSON serializable, Value: 0010-01-01 00:00:00"
+        error_string = "Object of type datetime is not JSON serializable, Value: 0010-01-01 00:00:00"
     assert issues == [
         'Could not JSON serialise a parameter ("d") - '
         "this must be serialisable so that we can execute "


### PR DESCRIPTION
 * add an example docker-compose which gets a running instance on 8080 which you can use to run the example template
 * get Dockerfile working again
 * get tests working on python > 3.6
 * fix passing of mongo username+password to child processes

It looks like there's still plenty of tidying up to do:
 * Docker image doesn't have the tex packages needed to render PDF #15 
 * python2 support code (e.g. `six`) can be cleaned up as the code which requires 3.5+ (e.g. type annotates) #16 
 * python package requirements are not frozen, so builds will soon be non-reproducible #17
 * build of docker image is not a part of the CI pipeline #18
 * there are unnecessary things in tests such as `assert sorted(d1.items()) == sorted(d2.items())`, as well as loops over things to see where elements differ (one was removed in this PR) - the latter are not needed in pytest (unlike unittest) as it gives nice diffs when things are not equal

On the front-end's _"Execute a Notebook"_ menu:
 * hidden directories (e.g. `.git`) are shown #19
 * _"Add a new notebook+"_ has a [bad link](http://ahlgit.maninvestments.com/projects/DATA/repos/notebooker/browse/notebook_templates/README.md)
 * clicking on sub-menu items can collapse the menu