### PR TITLE
Test isolation

### DIFF
--- a/notebooker/web/app.py
+++ b/notebooker/web/app.py
@@ -73,13 +73,19 @@ def setup_env_vars():
     config = getattr(settings, f"{notebooker_environment}Config")()
     set_vars = []
     logger.info("Running Notebooker with the following params:")
-    for attribute in (c for c in dir(config) if "__" not in c):
-        existing = os.getenv(attribute)
+    for attribute in dir(config):
+        if attribute.startswith("_"):
+            continue
+        existing = os.environ.get(attribute)
         if existing is None:
             os.environ[attribute] = str(getattr(config, attribute))
             set_vars.append(attribute)
+
         if "PASSWORD" not in attribute:
             logger.info(f"{attribute} = {os.environ[attribute]}")
+        else:
+            logger.info(f"{attribute} = *******")
+
     return set_vars
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,12 +1,14 @@
+import os
+
 import pytest
 
-TEST_DB_NAME = "notebookertest"
-TEST_LIB = "NB_OUTPUT"
+from notebooker.utils import caching
+from notebooker.web.config import settings
 
 
 @pytest.fixture
-def bson_library(mongo_server):
-    return mongo_server.api[TEST_DB_NAME][TEST_LIB]
+def bson_library(mongo_server, test_db_name, test_lib_name):
+    return mongo_server.api[test_db_name][test_lib_name]
 
 
 @pytest.fixture
@@ -15,10 +17,44 @@ def mongo_host(mongo_server):
 
 
 @pytest.fixture
-def test_db_name():
-    return TEST_DB_NAME
+def test_db_name(config):
+    return config.DATABASE_NAME
 
 
 @pytest.fixture
-def test_lib_name():
-    return TEST_LIB
+def test_lib_name(config):
+    return config.RESULT_COLLECTION_NAME
+
+@pytest.fixture
+def template_dir(workspace, monkeypatch):
+    monkeypatch.setenv("TEMPLATE_DIR", workspace.workspace)
+    return workspace.workspace
+
+@pytest.fixture
+def output_dir(workspace, monkeypatch):
+    monkeypatch.setenv("OUTPUT_DIR", workspace.workspace)
+    return workspace.workspace
+
+@pytest.fixture
+def config():
+    return settings.DevConfig
+
+
+@pytest.fixture
+def clean_file_cache(monkeypatch, workspace):
+    """Set up cache encironment."""
+    assert caching.cache is None
+    monkeypatch.setenv("CACHE_DIR", workspace.workspace)
+    yield
+    # purge the cache
+    caching.cache = None
+
+
+@pytest.fixture(autouse=True)
+def _unset_notebooker_environ(config):
+    """Remove Notebooker values from os.environ after each test."""
+    yield
+    for attribute in dir(config):
+        if attribute.startswith("_"):
+            continue
+        os.environ.pop(attribute, None)

--- a/tests/integration/test_e2e.py
+++ b/tests/integration/test_e2e.py
@@ -69,7 +69,10 @@ def environ(monkeypatch, mongo_host, workspace, test_db_name, test_lib_name):
     _setup_workspace(workspace)
     update = _environ(mongo_host, workspace, test_db_name, test_lib_name)
     for k, v in update.items():
-        monkeypatch.setenv(k, v)
+        if v is None:
+            monkeypatch.delenv(k, raising=False)
+        else:
+            monkeypatch.setenv(k, v)
 
 
 def _check_report_output(job_id, serialiser, **kwargs):

--- a/tests/integration/test_execute_notebook.py
+++ b/tests/integration/test_execute_notebook.py
@@ -1,6 +1,8 @@
 from __future__ import unicode_literals
 
 import mock
+import os
+
 from click.testing import CliRunner
 from nbformat import NotebookNode
 from nbformat import __version__ as nbv
@@ -8,6 +10,7 @@ from nbformat import __version__ as nbv
 from notebooker import execute_notebook
 from notebooker.constants import NotebookResultComplete
 from notebooker.serialization.serializers import PyMongoNotebookResultSerializer
+from notebooker.web.app import setup_env_vars
 
 
 def mock_nb_execute(input_path, output_path, **kw):
@@ -29,12 +32,17 @@ def test_main(mongo_host):
         exec_nb.side_effect = mock_nb_execute
         job_id = "ttttteeeesssstttt"
         runner = CliRunner()
+        # usually the parent process calls this and sets up the environment, then also explicitly passes
+        # values on the CLI
+        setup_env_vars()
         cli_result = runner.invoke(
             execute_notebook.main, ["--report-name", "test_report", "--mongo-host", mongo_host, "--job-id", job_id]
         )
         assert cli_result.exit_code == 0
         serializer = PyMongoNotebookResultSerializer(
-            mongo_host=mongo_host, database_name="notebooker", result_collection_name="NOTEBOOK_OUTPUT"
+            mongo_host=mongo_host,
+            database_name=os.environ["DATABASE_NAME"],
+            result_collection_name=os.environ["RESULT_COLLECTION_NAME"],
         )
         result = serializer.get_check_result(job_id)
         assert isinstance(result, NotebookResultComplete), "Result is not instance of {}, it is {}".format(

--- a/tests/integration/test_report_hunter.py
+++ b/tests/integration/test_report_hunter.py
@@ -8,13 +8,13 @@ from notebooker.constants import JobStatus, NotebookResultComplete, NotebookResu
 from notebooker.serialization.serialization import Serializer
 from notebooker.serialization.serializers import PyMongoNotebookResultSerializer
 from notebooker.utils.caching import get_report_cache
-from notebooker.utils.filesystem import initialise_base_dirs
 from notebooker.web.report_hunter import _report_hunter
 
-from ..utils import setup_and_cleanup_notebooker_filesystem
 
+@pytest.fixture(autouse=True)
+def clean_file_cache(clean_file_cache):
+    """Set up cache encironment."""
 
-@setup_and_cleanup_notebooker_filesystem
 def test_report_hunter_with_nothing(bson_library, mongo_host, test_db_name, test_lib_name):
     _report_hunter(
         Serializer.PYMONGO.value,
@@ -25,7 +25,6 @@ def test_report_hunter_with_nothing(bson_library, mongo_host, test_db_name, test
     )
 
 
-@setup_and_cleanup_notebooker_filesystem
 @freezegun.freeze_time(datetime.datetime(2018, 1, 12))
 def test_report_hunter_with_one(bson_library, mongo_host, test_db_name, test_lib_name):
     serializer = PyMongoNotebookResultSerializer(
@@ -52,9 +51,7 @@ def test_report_hunter_with_one(bson_library, mongo_host, test_db_name, test_lib
     assert get_report_cache(report_name, job_id) == expected
 
 
-@setup_and_cleanup_notebooker_filesystem
 def test_report_hunter_with_status_change(bson_library, mongo_host, test_db_name, test_lib_name):
-    initialise_base_dirs()
     serializer = PyMongoNotebookResultSerializer(
         database_name=test_db_name, mongo_host=mongo_host, result_collection_name=test_lib_name
     )
@@ -101,7 +98,6 @@ def test_report_hunter_with_status_change(bson_library, mongo_host, test_db_name
         assert get_report_cache(report_name, job_id) == expected
 
 
-@setup_and_cleanup_notebooker_filesystem
 @pytest.mark.parametrize(
     "status, time_later, should_timeout",
     [
@@ -169,7 +165,6 @@ def test_report_hunter_timeout(
         assert get_report_cache(report_name, job_id) == expected
 
 
-@setup_and_cleanup_notebooker_filesystem
 def test_report_hunter_pending_to_done(bson_library, mongo_host, test_db_name, test_lib_name):
     job_id = str(uuid.uuid4())
     report_name = str(uuid.uuid4())

--- a/tests/regression/test_execute_templates.py
+++ b/tests/regression/test_execute_templates.py
@@ -4,23 +4,19 @@ import uuid
 import pytest
 
 from notebooker.execute_notebook import _run_checks
-from notebooker.utils.filesystem import _cleanup_dirs, get_output_dir, get_template_dir
 
 from ..utils import _all_templates
 
 
 @pytest.mark.parametrize("template_name", _all_templates())
-def test_execution_of_templates(template_name):
-    try:
-        _run_checks(
-            "job_id_{}".format(str(uuid.uuid4())[:6]),
-            datetime.datetime.now(),
-            template_name,
-            template_name,
-            get_output_dir(),
-            get_template_dir(),
-            {},
-            generate_pdf_output=False,
-        )
-    finally:
-        _cleanup_dirs()
+def test_execution_of_templates(template_name, template_dir, output_dir):
+    _run_checks(
+        "job_id_{}".format(str(uuid.uuid4())[:6]),
+        datetime.datetime.now(),
+        template_name,
+        template_name,
+        output_dir,
+        template_dir,
+        {},
+        generate_pdf_output=False,
+    )

--- a/tests/sanity/test_template_sanity.py
+++ b/tests/sanity/test_template_sanity.py
@@ -3,30 +3,34 @@ from logging import getLogger
 import pytest
 
 from notebooker.utils.conversion import generate_ipynb_from_py
-from notebooker.utils.filesystem import get_template_dir
 from notebooker.utils.templates import _get_parameters_cell_idx, _get_preview, template_name_to_notebook_node
 
 from ..utils import _all_templates
 
 logger = getLogger("template_sanity_check")
 
+@pytest.fixture(autouse=True)
+def clean_file_cache(clean_file_cache):
+    pass
+
 
 @pytest.mark.parametrize("template_name", _all_templates())
-def test_conversion_doesnt_fail(template_name):
+def test_conversion_doesnt_fail(template_name, template_dir):
     # Test conversion to ipynb - this will throw if stuff goes wrong
-    generate_ipynb_from_py(get_template_dir(), template_name, warn_on_local=False)
+    generate_ipynb_from_py(template_dir, template_name, warn_on_local=False)
 
 
 @pytest.mark.parametrize("template_name", _all_templates())
-def test_template_has_parameters(template_name):
-    generate_ipynb_from_py(get_template_dir(), template_name, warn_on_local=False)
+def test_template_has_parameters(template_name, template_dir):
+    generate_ipynb_from_py(template_dir, template_name, warn_on_local=False)
     nb = template_name_to_notebook_node(template_name, warn_on_local=False)
     metadata_idx = _get_parameters_cell_idx(nb)
     assert metadata_idx is not None, 'Template {} does not have a "parameters"-tagged cell.'.format(template_name)
 
 
 @pytest.mark.parametrize("template_name", _all_templates())
-def test_template_can_generate_preview(template_name):
+def test_template_can_generate_preview(template_dir, template_name):
+    print(template_name)
     preview = _get_preview(template_name, warn_on_local=False)
     # Previews in HTML are gigantic since they include all jupyter css and js.
     assert len(preview) > 1000, "Preview was not properly generated for {}".format(template_name)


### PR DESCRIPTION
This a commit on top of #14

 * DRY up subprocess entry point
 * isolate the environment variables between tests
 * reset file cache between tests

In removing the defaults from the subprocess (which look like they should come from the parent process and it's method of getting defaults), a fair few tests broke, and it looks like tests relied on side-effects of others or those defaults. The change touched a fair chunk of tests as a result.

## Notes on `notebooker.execute_notebook.main`
It looks like it could be good to refactor the code to avoid the use of environment variables down in the code (e.g. `get_cache_dir()`), and to instead only have it on the entrypoints - this should help isolation a bit. Click supports it for options [[docs](https://click.palletsprojects.com/en/7.x/options/#values-from-environment-variables)], and there are also there are things like [`pydantic.BaseSettings`](https://pydantic-docs.helpmanual.io/usage/settings/) which can be used.

Given that the settings are used in two places (the server, and the child processes), I think something like `pydantic.BaseSettings` would be DRYer as you have one magically instantiating class to gather and sanitise all of the variables, rather than duplicating CLI options on the two entrypoints.

This would also move away from the having the config baked into the codebase which is switched using an environment variable, so you'd have less indirection, and also separate code from deployment.