### PR TITLE
Add --disable-scheduler and fix template sanity/regression testing

### DIFF
--- a/notebooker/_entrypoints.py
+++ b/notebooker/_entrypoints.py
@@ -110,6 +110,13 @@ def base_notebooker(
     help="Where the filesystem-based short-term cache stores its data.",
 )
 @click.option(
+    "--disable-scheduler",
+    default=False,
+    is_flag=True,
+    help="If --disable-scheduler is given, then the scheduling back-end of the webapp will not start up. It will also "
+         "not display the scheduler from the front-end of the webapp."
+)
+@click.option(
     "--scheduler-mongo-database",
     default=DEFAULT_DATABASE_NAME,
     help=f"The name of the mongo database which is used for the scheduling back-end. "
@@ -123,13 +130,14 @@ def base_notebooker(
 )
 @pass_config
 def start_webapp(
-    config: BaseConfig, port, logging_level, debug, base_cache_dir, scheduler_mongo_database, scheduler_mongo_collection
+    config: BaseConfig, port, logging_level, debug, base_cache_dir, disable_scheduler, scheduler_mongo_database, scheduler_mongo_collection
 ):
     web_config = WebappConfig.copy_existing(config)
     web_config.PORT = port
     web_config.LOGGING_LEVEL = logging_level
     web_config.DEBUG = debug
     web_config.CACHE_DIR = base_cache_dir
+    web_config.DISABLE_SCHEDULER = disable_scheduler
     web_config.SCHEDULER_MONGO_DATABASE = scheduler_mongo_database
     web_config.SCHEDULER_MONGO_COLLECTION = scheduler_mongo_collection
     return main(web_config)

--- a/notebooker/settings.py
+++ b/notebooker/settings.py
@@ -47,3 +47,4 @@ class WebappConfig(BaseConfig):
 
     SCHEDULER_MONGO_DATABASE: str = ""
     SCHEDULER_MONGO_COLLECTION: str = ""
+    DISABLE_SCHEDULER: bool = False

--- a/notebooker/utils/template_testing.py
+++ b/notebooker/utils/template_testing.py
@@ -26,6 +26,7 @@ def setup_test(template_dir):
             web_config = WebappConfig()
             web_config.PY_TEMPLATE_BASE_DIR = template_dir
             web_config.CACHE_DIR = tmpdir
+            web_config.DISABLE_SCHEDULER = True
             app = setup_app(app, web_config)
             with app.app_context():
                 yield
@@ -36,10 +37,10 @@ def setup_test(template_dir):
 @click.command()
 @click.option("--template-dir", default="notebook_templates")
 def sanity_check(template_dir):
-    logger.info("Starting sanity check")
+    logger.info(f"Starting sanity check in {template_dir}")
     with setup_test(template_dir):
         for template_name in notebooker.web.utils._all_templates():
-            logger.info("========================[ Sanity checking {} ]========================".format(template_name))
+            logger.info(f"========================[ Sanity checking {template_name} ]========================")
             # Test conversion to ipynb - this will throw if stuff goes wrong
             generate_ipynb_from_py(
                 filesystem.get_template_dir(),
@@ -55,7 +56,7 @@ def sanity_check(template_dir):
             )
             param_idx = templates._get_parameters_cell_idx(nb)
             if param_idx is None:
-                logger.warning('Template {} does not have a "parameters"-tagged cell.'.format(template_name))
+                logger.warning(f'Template {template_name} does not have a "parameters"-tagged cell.')
 
             # Test that we can generate a preview from the template
             preview = templates._get_preview(
@@ -65,8 +66,8 @@ def sanity_check(template_dir):
                 warn_on_local=False,
             )
             # Previews in HTML are gigantic since they include all jupyter css and js.
-            assert len(preview) > 1000, "Preview was not properly generated for {}".format(template_name)
-            logger.info("========================[ {} PASSED ]========================".format(template_name))
+            assert len(preview) > 1000, f"Preview was not properly generated for {template_name}"
+            logger.info(f"========================[ {template_name} PASSED ]========================")
 
 
 @click.command()
@@ -76,7 +77,7 @@ def regression_test(template_dir):
     with setup_test(template_dir):
         attempted_templates, failed_templates = [], set()
         for template_name in notebooker.web.utils._all_templates():
-            logger.info("============================[ Testing {} ]============================".format(template_name))
+            logger.info(f"============================[ Testing {template_name} ]============================")
             try:
                 attempted_templates.append(template_name)
                 _run_checks(
@@ -94,7 +95,7 @@ def regression_test(template_dir):
             except Exception:
                 failed_templates.add(template_name)
                 logger.info("===============================[ FAILED ]===============================")
-                logger.exception("Failed to execute template {}".format(template_name))
+                logger.exception(f"Failed to execute template {template_name}")
 
         for template in attempted_templates:
             logger.info("{}: {}".format(template, "FAILED" if template in failed_templates else "PASSED"))

--- a/notebooker/web/routes/scheduling.py
+++ b/notebooker/web/routes/scheduling.py
@@ -3,7 +3,7 @@ from typing import Optional, List
 import uuid
 
 from apscheduler.jobstores.base import ConflictingIdError
-from flask import Blueprint, jsonify, render_template, current_app, request, url_for
+from flask import Blueprint, jsonify, render_template, current_app, request, url_for, abort
 
 from notebooker.utils.web import json_to_python
 from notebooker.web.handle_overrides import handle_overrides
@@ -12,6 +12,13 @@ from notebooker.web.utils import get_all_possible_templates
 from apscheduler.triggers import cron
 
 scheduling_bp = Blueprint("scheduling_bp", __name__)
+
+
+@scheduling_bp.route("/scheduler/health")
+def scheduler_is_up():
+    if not hasattr(current_app, "apscheduler") or current_app.apscheduler is None:
+        abort(404)
+    return jsonify({"status": "OK"})  # TODO: Add an actual health check here
 
 
 @scheduling_bp.route("/scheduler")

--- a/notebooker/web/static/notebooker/header.js
+++ b/notebooker/web/static/notebooker/header.js
@@ -26,6 +26,15 @@ $(document).ready(() => {
             $('#authArea').hide();
         },
     });
+    $.ajax({
+        url: '/scheduler/health',
+        success: () => {
+            // Show the status at some point
+        },
+        error: () => {
+            $('#schedulerButton').hide();
+        },
+    });
 
     const sb = $('.ui.left.sidebar');
     sb.sidebar({

--- a/notebooker/web/static/notebooker/index.js
+++ b/notebooker/web/static/notebooker/index.js
@@ -47,63 +47,75 @@ load_data = (limit) => {
 
 
 $(document).ready(() => {
-    $('#resultsTable').DataTable({
-        columns: [
-            {
-                title: 'Title',
-                name: 'title',
-                data: 'report_title',
-            },
-            {
-                title: 'Report Template Name',
-                name: 'report_name',
-                data: 'report_name',
-            },
-            {
-                title: 'Status',
-                name: 'status',
-                data: 'status',
-            },
-            {
-                title: 'Start Time',
-                name: 'job_start_time',
-                data: 'job_start_time',
-                render: (dt) => {
-                    const d = new Date(dt);
-                    return d.toISOString().replace('T', ' ').slice(0, 19);
-                },
-            },
-            {
-                title: 'Completion Time',
-                name: 'job_finish_time',
-                data: 'job_finish_time',
-                render: (dt) => {
-                    if (dt) {
-                        const d = new Date(dt);
-                        return d.toISOString().replace('T', ' ').slice(0, 19);
-                    }
-                    return '';
-                },
-            },
-            {
-                title: 'Results',
-                name: 'result_url',
-                data: 'result_url',
-                render: (url) => `<button onclick="location.href='${url}'" type="button" `
-                        + 'class="ui button blue">Result</button>',
-            },
-            {
-                title: 'PDF',
-                name: 'pdf_url',
-                data: 'pdf_url',
-                render: (url, type, row) => {
-                    if (row.generate_pdf_output) {
-                        return `<button onclick="location.href='${url}'" type="button" `
-                            + 'class="ui button green"><i class="download icon"></i></button>';
-                    }
-                    return '';
-                },
-            },
+    let columns = [
+    {
+        title: 'Title',
+        name: 'title',
+        data: 'report_title',
+    },
+    {
+        title: 'Report Template Name',
+        name: 'report_name',
+        data: 'report_name',
+    },
+    {
+        title: 'Status',
+        name: 'status',
+        data: 'status',
+    },
+    {
+        title: 'Start Time',
+        name: 'job_start_time',
+        data: 'job_start_time',
+        render: (dt) => {
+            const d = new Date(dt);
+            return d.toISOString().replace('T', ' ').slice(0, 19);
+        },
+    },
+    {
+        title: 'Completion Time',
+        name: 'job_finish_time',
+        data: 'job_finish_time',
+        render: (dt) => {
+            if (dt) {
+                const d = new Date(dt);
+                return d.toISOString().replace('T', ' ').slice(0, 19);
+            }
+            return '';
+        },
+    },
+    {
+        title: 'Results',
+        name: 'result_url',
+        data: 'result_url',
+        render: (url) => `<button onclick="location.href='${url}'" type="button" `
+                + 'class="ui button blue">Result</button>',
+    },
+    {
+        title: 'PDF',
+        name: 'pdf_url',
+        data: 'pdf_url',
+        render: (url, type, row) => {
+            if (row.generate_pdf_output) {
+                return `<button onclick="location.href='${url}'" type="button" `
+                    + 'class="ui button green"><i class="download icon"></i></button>';
+            }
+            return '';
+        },
+    }]
+    var usingScheduler = undefined;
+    $.ajax({
+        async: false,
+        url: '/scheduler/health',
+        success: () => {
+            usingScheduler = true;
+        },
+        error: () => {
+            usingScheduler = false;
+        },
+    });
+    if (usingScheduler === true) {
+        columns = columns.concat([
             {
                 title: 'Scheduler Job',
                 name: 'scheduler_job_id',
@@ -115,23 +127,28 @@ $(document).ready(() => {
                         return '';
                     }
                 }
-            },
-            {
-                title: 'Rerun',
-                name: 'rerun_url',
-                data: 'rerun_url',
-                render: (url, type, row) => `<button onclick="rerunReport('${row.job_id}', '${url}')" `
-                           + 'type="button" class="ui yellow button rerunButton">'
-                        + '<i class="redo alternate icon"></i>Rerun</button>',
-            },
-            {
-                title: 'Delete',
-                name: 'result_url',
-                data: 'result_url',
-                render: (url, type, row) => `${'<button type="button" class="ui button red deletebutton" '
-                        + 'id="delete_'}${row.job_id}"> <i class="trash icon"></i>`,
-            },
-        ],
+            }
+        ])
+    }
+    columns = columns.concat([
+        {
+            title: 'Rerun',
+            name: 'rerun_url',
+            data: 'rerun_url',
+            render: (url, type, row) => `<button onclick="rerunReport('${row.job_id}', '${url}')" `
+                       + 'type="button" class="ui yellow button rerunButton">'
+                    + '<i class="redo alternate icon"></i>Rerun</button>',
+        },
+        {
+            title: 'Delete',
+            name: 'result_url',
+            data: 'result_url',
+            render: (url, type, row) => `${'<button type="button" class="ui button red deletebutton" '
+                    + 'id="delete_'}${row.job_id}"> <i class="trash icon"></i>`,
+        },
+    ])
+    $('#resultsTable').DataTable({
+        columns: columns,
         order: [[3, 'desc']],
     });
     load_data(50);

--- a/notebooker/web/templates/header.html
+++ b/notebooker/web/templates/header.html
@@ -40,7 +40,7 @@
           <a class="item" id="runReport">
               Execute a Notebook
           </a>
-          <a class="item" href="/scheduler">
+          <a class="item" id="schedulerButton" href="/scheduler">
               Scheduler
           </a>
           <div class="right menu" id="authArea">

--- a/tests/integration/test_template_testing.py
+++ b/tests/integration/test_template_testing.py
@@ -1,0 +1,14 @@
+from pathlib import Path
+from click.testing import CliRunner
+
+from notebooker.utils.template_testing import regression_test
+
+
+def test_regression_testing():
+    from notebooker import notebook_templates_example
+    f = Path(notebook_templates_example.__file__).parent / "sample"
+    runner = CliRunner()
+    result = runner.invoke(regression_test, ["--template-dir", f])
+    assert not result.exception, result.output
+    assert result.exit_code == 0
+

--- a/tests/unit/utils/test_template_testing.py
+++ b/tests/unit/utils/test_template_testing.py
@@ -1,0 +1,14 @@
+from pathlib import Path
+from click.testing import CliRunner
+
+from notebooker.utils.template_testing import sanity_check
+
+
+def test_sanity_checking():
+    from notebooker import notebook_templates_example
+    f = Path(notebook_templates_example.__file__).parent / "sample"
+    runner = CliRunner()
+    result = runner.invoke(sanity_check, ["--template-dir", f])
+    assert not result.exception, result.output
+    assert result.exit_code == 0
+


### PR DESCRIPTION
Previously the sanity/regression tests would try to set up the scheduler with no config at all. This adds tests for these CLI runners and also ensures that we can nicely disable the scheduler as a side effect.