### PR TITLE
Command-line report timeout parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,9 @@
-0.4.1 (2022-01-??)
+0.4.1 (2022-02-??)
 ------------------
 
 * Improvement: The email "from" address is now fully configurable.
 * Bugfix: The default "from" email address domain is no longer non-existent.
+* Improvement: --running-timeout parameter allows customization of max allowed notebook runtime
 
 0.4.0 (2021-12-17)
 ------------------

--- a/docs/templates.rst
+++ b/docs/templates.rst
@@ -27,10 +27,10 @@ To use a git repository as a notebook templates repository, you simply need to c
 :code:`notebook_requirements.txt`, containing extra package requirements to be
 installed, should be added to that folder.
 
-For Notebooker to use a your checked-out repository, set two environment variables:
+For Notebooker to use a your checked-out repository, set two command-line parameters:
 
-* Set :code:`PY_TEMPLATE_BASE_DIR` to the checked-out repository
-* Set :code:`PY_TEMPLATE_SUBDIR` to the subdirectory within your git repo which contains the templates
+* Set :code:`--py-template-base-dir` to the checked-out repository
+* Set :code:`--py-template-subdir` to the subdirectory within your git repo which contains the templates
 
 Adding parameters
 -----------------

--- a/notebooker/_entrypoints.py
+++ b/notebooker/_entrypoints.py
@@ -5,7 +5,7 @@ import click
 
 from notebooker import notebook_templates_example
 from notebooker.version import __version__
-from notebooker.constants import DEFAULT_SERIALIZER, DEFAULT_MAILFROM_ADDRESS
+from notebooker.constants import DEFAULT_SERIALIZER, DEFAULT_MAILFROM_ADDRESS, DEFAULT_RUNNING_TIMEOUT
 from notebooker.execute_notebook import execute_notebook_entrypoint
 from notebooker.serialization import SERIALIZER_TO_CLI_OPTIONS
 from notebooker.settings import BaseConfig, WebappConfig
@@ -69,6 +69,12 @@ def filesystem_default_value(dirname):
     help="Set a new value for the default mailfrom setting."
 )
 @click.option(
+    "--running-timeout",
+    default=DEFAULT_RUNNING_TIMEOUT,
+    help="Timeout in minutes for report execution",
+    type=int
+)
+@click.option(
     "--serializer-cls",
     default=DEFAULT_SERIALIZER,
     help="The serializer class through which we will save the notebook result.",
@@ -83,6 +89,7 @@ def base_notebooker(
     py_template_subdir,
     notebooker_disable_git,
     default_mailfrom,
+    running_timeout,
     serializer_cls,
     **serializer_args,
 ):
@@ -96,6 +103,7 @@ def base_notebooker(
         PY_TEMPLATE_SUBDIR=py_template_subdir,
         NOTEBOOKER_DISABLE_GIT=notebooker_disable_git,
         DEFAULT_MAILFROM=default_mailfrom,
+        RUNNING_TIMEOUT=running_timeout,
     )
     ctx.obj = config
 

--- a/notebooker/constants.py
+++ b/notebooker/constants.py
@@ -7,7 +7,7 @@ from typing import AnyStr, Optional
 import attr
 
 SUBMISSION_TIMEOUT = 3
-RUNNING_TIMEOUT = 60
+DEFAULT_RUNNING_TIMEOUT = 60
 DEFAULT_RESULT_LIMIT = 100
 CANCEL_MESSAGE = "The webapp shut down while this job was running. Please resubmit with the same parameters."
 TEMPLATE_DIR_SEPARATOR = "^"

--- a/notebooker/settings.py
+++ b/notebooker/settings.py
@@ -2,7 +2,7 @@ from typing import Dict
 
 from dataclasses import dataclass, asdict
 
-from notebooker.constants import DEFAULT_SERIALIZER, DEFAULT_MAILFROM_ADDRESS
+from notebooker.constants import DEFAULT_SERIALIZER, DEFAULT_MAILFROM_ADDRESS, DEFAULT_RUNNING_TIMEOUT
 
 
 @dataclass
@@ -32,6 +32,8 @@ class BaseConfig:
 
     # Value used in the from header of emails sent by notebooker if the user doesn't pass one when running a notebook
     DEFAULT_MAILFROM: str = DEFAULT_MAILFROM_ADDRESS
+
+    RUNNING_TIMEOUT: int = DEFAULT_RUNNING_TIMEOUT
 
     @classmethod
     def copy_existing(cls, existing: "BaseConfig"):

--- a/notebooker/web/report_hunter.py
+++ b/notebooker/web/report_hunter.py
@@ -3,7 +3,7 @@ import os
 import time
 from logging import getLogger
 
-from notebooker.constants import RUNNING_TIMEOUT, SUBMISSION_TIMEOUT, JobStatus
+from notebooker.constants import SUBMISSION_TIMEOUT, JobStatus
 from notebooker.serialization.serialization import initialize_serializer_from_config
 from notebooker.utils.caching import get_report_cache, set_report_cache
 from notebooker.settings import WebappConfig
@@ -37,7 +37,7 @@ def _report_hunter(webapp_config: WebappConfig, run_once: bool = False, timeout:
             now = datetime.datetime.now()
             cutoff = {
                 JobStatus.SUBMITTED: now - datetime.timedelta(minutes=SUBMISSION_TIMEOUT),
-                JobStatus.PENDING: now - datetime.timedelta(minutes=RUNNING_TIMEOUT),
+                JobStatus.PENDING: now - datetime.timedelta(minutes=webapp_config.RUNNING_TIMEOUT),
             }
             cutoff.update({k.value: v for (k, v) in cutoff.items()})  # Add value to dict for backwards compat
             for result in all_pending:


### PR DESCRIPTION
Adds additional notebooker-cli command-line parameter to configure report timeouts.

Keeps default of 60.

Also fixed documentation that still referred to environment variable setting for python template directories.