### PR TITLE
fixing cron conversion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 ------------------
 * Feature: Allow configuring error email addresses via UI. 
 * Bugfix: . and .. should now be allowed to be used when specifying the templates directory.
-
+* Bugfix: corrected cron schedule incorrectly shifting back one day upon save.
 
 
 0.5.1 (2023-02-22)

--- a/tests/unit/test_convert_day_of_week.py
+++ b/tests/unit/test_convert_day_of_week.py
@@ -1,16 +1,42 @@
-from notebooker.web.routes.scheduling import convert_day_of_week
+from notebooker.web.routes.scheduling import crontab_to_apscheduler_day_of_week
+from notebooker.web.routes.scheduling import apscheduler_to_crontab_day_of_week
 
 
-def test_weekdays():
-    result = convert_day_of_week("1-5")
+def test_to_appscheduler_days():
+    result = crontab_to_apscheduler_day_of_week("0,1,2,3,4,5,6")
+    assert result == "6,0,1,2,3,4,5"
+
+
+def test_to_crontab_days():
+    result = apscheduler_to_crontab_day_of_week("6,0,1,2,3,4,5")
+    assert result == "0,1,2,3,4,5,6"
+
+
+def test_to_appscheduler_weekdays():
+    result = crontab_to_apscheduler_day_of_week("1-5")
     assert result == "0-4"
 
 
-def test_sunday():
-    result = convert_day_of_week("0")
+def test_to_crontab_weekdays():
+    result = apscheduler_to_crontab_day_of_week("0-4")
+    assert result == "1-5"
+
+
+def test_to_appscheduler_sunday():
+    result = crontab_to_apscheduler_day_of_week("0")
     assert result == "6"
 
 
-def test_string_days():
-    result = convert_day_of_week("MON-FRI")
+def test_to_crontab_sunday():
+    result = apscheduler_to_crontab_day_of_week("6")
+    assert result == "0"
+
+
+def test_to_appscheduler_string_days():
+    result = crontab_to_apscheduler_day_of_week("MON-FRI")
+    assert result == "MON-FRI"
+
+
+def test_to_crontab_string_days():
+    result = apscheduler_to_crontab_day_of_week("MON-FRI")
     assert result == "MON-FRI"


### PR DESCRIPTION
A while ago a change was made to convert between crontab and apscheduler days of week - https://github.com/man-group/notebooker/pull/115/commits/cadba46ec9f02715d3b035f478b2ad96cf17d920#diff-490c71dda64b8e9aab6c585e5cab2133d798ff6b14f792dcf85ca667aa69be90

However that conversion was done only one way and each time ones saves the schedule the conversion happens shifting the days incorrectly.

A fix is to shift the days back to the crontab format when presenting to the UI