### PR TITLE
Fixing docker compose

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -7,9 +7,8 @@ COPY . /workspace
 
 WORKDIR /workspace/notebooker/web/static
 RUN set -eux \
-  ; yarn install --frozen-lockfile \
-  ; yarn list --depth=0 \
-  ; yarn run lint \
+  ; npm install \
+  ; yarn bundle \
   ; ls -lah node_modules
 
 
@@ -32,6 +31,7 @@ WORKDIR /workspace
 RUN set -eux \
   ; pip install -e ".[prometheus, test, docs]" \
   ; python -m ipykernel install --user --name=notebooker_kernel \
+  ; pip install nbformat jupyter-core jupyter-client --upgrade \
   ; pip install -r ./notebooker/notebook_templates_example/notebook_requirements.txt \
   ; python setup.py develop \
   ; python setup.py build_sphinx \
@@ -39,11 +39,11 @@ RUN set -eux \
   ; python setup.py bdist_wheel --universal
 
 
-FROM continuumio/anaconda3:2020.07-alpine
+FROM continuumio/anaconda3
 USER root
-# FIXME: more is needed to generate PDFs: latest error is `LaTeX Error: File `tcolorbox.sty' not found.`
-RUN apk add git texlive-xetex
-USER anaconda
+
+# Needed for PDF generation
+RUN apt-get update && apt-get install -y git texlive-xetex
 
 WORKDIR /app
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -31,7 +31,7 @@ WORKDIR /workspace
 RUN set -eux \
   ; pip install -e ".[prometheus, test, docs]" \
   ; python -m ipykernel install --user --name=notebooker_kernel \
-  ; pip install nbformat jupyter-core jupyter-client --upgrade \
+  ; pip install nbformat jupyter-core jupyter-client Pandoc --upgrade \
   ; pip install -r ./notebooker/notebook_templates_example/notebook_requirements.txt \
   ; python setup.py develop \
   ; python setup.py build_sphinx \

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -17,7 +17,7 @@ services:
       PY_TEMPLATE_BASE_DIR: /var/run/template_repo
     volumes:
       - git-repo:/var/run/template_repo
-    command: ["notebooker-cli", "--mongo-host", "${MONGO_HOST}", "--mongo-user", "${MONGO_USER}", "--mongo-password", "${MONGO_USER}", "start-webapp", "--port", "${PORT}"]
+    command: ["notebooker-cli", "--mongo-host", "mongodb:27017", "--mongo-user", "root", "--mongo-password", "toor", "start-webapp", "--port", "11828"]
     ports:
       - "8080:11828"
     depends_on:

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -1,8 +1,6 @@
 version: "3"
 
 services:
-  # note:
-  #  * the templates' required python modules must be baked into the image
   notebooker:
     build:
       context: ..
@@ -11,20 +9,17 @@ services:
       # config variables are defined in notebooker/web/config/setting.py
       PORT: 11828
       LOGGING_LEVEL: info
-
       MONGO_USER: root
       MONGO_PASSWORD: toor
       MONGO_HOST: mongodb:27017
-      # this should be something like "notebooker" but this simplifies the compose file
       DATABASE_NAME: admin
       RESULT_COLLECTION_NAME: NOTEBOOK_OUTPUT
-
       PY_TEMPLATE_BASE_DIR: /var/run/template_repo
     volumes:
       - git-repo:/var/run/template_repo
-    command: ["notebooker_webapp"]
+    command: ["notebooker-cli", "--mongo-host", "${MONGO_HOST}", "--mongo-user", "${MONGO_USER}", "--mongo-password", "${MONGO_USER}", "start-webapp", "--port", "${PORT}"]
     ports:
-      - 8080:11828
+      - "8080:11828"
     depends_on:
       - mongodb
     restart: always


### PR DESCRIPTION
The existing Docker file and docker-compose.yaml seemed out of sync with the current release. `notebooker_webapp` is no longer the correct command to launch the app, runtime args need updating, and some of the expected dependencies are not fulfilled by the `continuumio/anaconda3:2020.07-alpine` image. This commit addresses this and allows 
```sh
cd docker
docker compose up
```
to bring up notebooker without complaint again.