### PR TITLE
Fix input cell hiding in nbconvert>6

### DIFF
--- a/notebooker/nbtemplates/notebooker_html_output.tpl
+++ b/notebooker/nbtemplates/notebooker_html_output.tpl
@@ -38,25 +38,37 @@ div div.cell {
     var code_blocks = [
     	'.input',
     	'.prompt',
-    	'.output_stream'
+    	'.output_stream',
+    	'.jp-outputPrompt',
+    	'.jp-inputPrompt',
+    	'.jp-InputArea-editor',
+    	'.jp-RenderedText'
     ];
     var show_code = function(){
         code_blocks.forEach(
-            function(block){
-                $(block).show()
+	        function(block){
+	            var elements = document.querySelectorAll(block);
+				for(var i = 0; i < elements.length; i++){
+				    elements[i].style.display = '';
+				}
             }
         )
     };
 	var hide_code = function(){
 	    code_blocks.forEach(
 	        function(block){
-	            $(block).hide()
+	            var elements = document.querySelectorAll(block);
+				for(var i = 0; i < elements.length; i++){
+				    elements[i].style.display = 'none';
+				}
             }
         )
     };
 
-
-	var bodyElement = $('#notebook-container')[0];
+    var bodyElement = document.getElementsByClassName('jp-Notebook')[0];
+    if (bodyElement === undefined) {
+        bodyElement = document.getElementById('notebook-container');
+    }
     var toggleDiv = document.createElement('div');
     var toggleButton = document.createElement('button');
     toggleButton.className = 'btn';
@@ -81,6 +93,6 @@ div div.cell {
 
 {% block stream %}
   {%- if resources.global_content_filter.include_output_prompt -%}
-    {{ super() }}
+    {{ super() or "" }}
   {%- endif -%}
 {%- endblock stream %}

--- a/notebooker/utils/conversion.py
+++ b/notebooker/utils/conversion.py
@@ -36,6 +36,7 @@ def ipython_to_html(
             __name__, "../nbtemplates/notebooker_html_output.tpl"
         )
         c.HTMLExporter.exclude_input = hide_code
+        c.HTMLExporter.exclude_input_prompt = hide_code
         c.HTMLExporter.exclude_output_prompt = hide_code
         html_exporter_with_figs = HTMLExporter(config=c)
         resources_dir = get_resources_dir(job_id)
@@ -47,6 +48,7 @@ def ipython_to_html(
 def ipython_to_pdf(raw_executed_ipynb: str, report_title: str, hide_code: bool = False) -> AnyStr:
     c = Config()
     c.PDFExporter.exclude_input = hide_code
+    c.PDFExporter.exclude_input_prompt = hide_code
     c.PDFExporter.exclude_output_prompt = hide_code
     c.HTMLExporter.template_file = pkg_resources.resource_filename(
         __name__, "../nbtemplates/notebooker_pdf_output.tplx"


### PR DESCRIPTION
- Fix the Notebooker HTML output, which adds a button to toggle code/logging outputs, in newer versions of nbconvert. 
- Set exclude_input_prompt on nbconvert Exporters to actually hide code in PDF/HTML outputs.