### PR TITLE
#165: Fix the word "None" appearing at the top of each report

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+0.6.2 (2024-xx-xx)
+------------------
+* Bugfix: None will stop appearing at the top of reports with nbconvert>7.0.0
+
 0.6.1 (2023-09-13)
 ------------------
 * Feature: GridFS document storage in Mongo-backed instances is now sharded if the mongo server supports it. 

--- a/notebooker/nbtemplates/notebooker_html_output_deprecated.tpl
+++ b/notebooker/nbtemplates/notebooker_html_output_deprecated.tpl
@@ -1,4 +1,4 @@
-{% extends 'index.html.j2' %}
+{% extends 'full.tpl' %}
 {% block html_head %}
 {{ super() }}
 <style type="text/css">

--- a/notebooker/utils/conversion.py
+++ b/notebooker/utils/conversion.py
@@ -4,10 +4,12 @@ from typing import Any, AnyStr, Dict, Optional
 
 import git
 import jupytext
+import nbconvert
 import nbformat
 import pkg_resources
 from nbconvert import HTMLExporter, PDFExporter, SlidesExporter
 from nbconvert.exporters.exporter import ResourcesDict
+from packaging import version
 from traitlets.config import Config
 
 from notebooker.constants import TEMPLATE_DIR_SEPARATOR, kernel_spec
@@ -32,9 +34,14 @@ def ipython_to_html(
         html, resources = exporter.from_notebook_node(nb)
     else:
         c.HTMLExporter.preprocessors = ["nbconvert.preprocessors.ExtractOutputPreprocessor"]
+        if version.parse(nbconvert.__version__) >= version.parse("7.0.0"):
+            template_filename = "notebooker_html_output.tpl"
+        else:
+            template_filename = "notebooker_html_output_deprecated.tpl"
         c.HTMLExporter.template_file = pkg_resources.resource_filename(
-            __name__, "../nbtemplates/notebooker_html_output.tpl"
+            __name__, f"../nbtemplates/{template_filename}"
         )
+
         c.HTMLExporter.exclude_input = hide_code
         c.HTMLExporter.exclude_input_prompt = hide_code
         c.HTMLExporter.exclude_output_prompt = hide_code


### PR DESCRIPTION
This occurs when nbconvert>7.0.0. This is due to the deprecation of the `full.tpl` template file; the deprecation notice just prints None instead of a deprecation notice :) 

This change also pins nbconvert to a minimum version of 7.0.0 to ensure the fix works on this version of Notebooker.

Fixes #165 