### PR TITLE
passing mailfrom around

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 0.6.2 (2024-05-xx)
 ------------------
 * Chore: Applying & enforcing Black and Prettier to Python and JS code, respectively. Setting Black version to 22.8.0 for CircleCI.
+* Bugfix: Preserve the "mailfrom" parameter on notebook rerun.
 
 0.6.1 (2024-02-26)
 ------------------

--- a/notebooker/execute_notebook.py
+++ b/notebooker/execute_notebook.py
@@ -514,6 +514,7 @@ def run_report_in_subprocess(
         scheduler_job_id=scheduler_job_id,
         is_slideshow=is_slideshow,
         email_subject=email_subject,
+        mailfrom=mailfrom,
     )
 
     command = (

--- a/notebooker/serialization/mongo.py
+++ b/notebooker/serialization/mongo.py
@@ -208,6 +208,7 @@ class MongoResultSerializer(ABC):
         scheduler_job_id: Optional[str] = None,
         is_slideshow: bool = False,
         email_subject: Optional[str] = None,
+        mailfrom: Optional[str] = None,
     ) -> None:
         """Call this when we are just starting a check. Saves a "pending" job into storage."""
         job_start_time = job_start_time or datetime.datetime.now()
@@ -226,6 +227,7 @@ class MongoResultSerializer(ABC):
             hide_code=hide_code,
             scheduler_job_id=scheduler_job_id,
             is_slideshow=is_slideshow,
+            mailfrom=mailfrom,
         )
         self._save_to_db(pending_result)
 
@@ -316,6 +318,7 @@ class MongoResultSerializer(ABC):
                 generate_pdf_output=result.get("generate_pdf_output", True),
                 report_title=result.get("report_title", result["report_name"]),
                 mailto=result.get("mailto", ""),
+                mailfrom=result.get("mailfrom", ""),
                 error_mailto=result.get("error_mailto", ""),
                 hide_code=result.get("hide_code", False),
                 stdout=result.get("stdout", []),
@@ -334,6 +337,7 @@ class MongoResultSerializer(ABC):
                 generate_pdf_output=result.get("generate_pdf_output", True),
                 report_title=result.get("report_title", result["report_name"]),
                 mailto=result.get("mailto", ""),
+                mailfrom=result.get("mailfrom", ""),
                 error_mailto=result.get("error_mailto", ""),
                 email_subject=result.get("email_subject", ""),
                 hide_code=result.get("hide_code", False),
@@ -359,6 +363,7 @@ class MongoResultSerializer(ABC):
                 generate_pdf_output=result.get("generate_pdf_output", True),
                 report_title=result.get("report_title", result["report_name"]),
                 mailto=result.get("mailto", ""),
+                mailfrom=result.get("mailfrom", ""),
                 error_mailto=result.get("error_mailto", ""),
                 email_subject=result.get("email_subject", ""),
                 hide_code=result.get("hide_code", False),

--- a/notebooker/web/routes/report_execution.py
+++ b/notebooker/web/routes/report_execution.py
@@ -261,6 +261,7 @@ def _rerun_report(job_id, prepare_only=False, run_synchronously=False):
         run_synchronously=run_synchronously,
         is_slideshow=result.is_slideshow,
         email_subject=result.email_subject,
+        mailfrom=result.mailfrom,
     )
     return new_job_id
 

--- a/notebooker/web/templates/results.html
+++ b/notebooker/web/templates/results.html
@@ -62,6 +62,9 @@
                 {% if result.error_mailto %}
                     <h4>Mailing errors to:</h4> {{ result.error_mailto }}
                 {% endif %}
+                {% if result.mailfrom %}
+                    <h4>Mailing results from:</h4> {{ result.mailfrom }}
+                {% endif %}
                 {% if result.email_subject %}
                     <h4>Email subject:</h4> {{ result.email_subject }}
                 {% endif %}


### PR DESCRIPTION
This is so that mailfrom is preserved on notebooker re-run and shows up on the param list on the right hand side