### PR TITLE
Encode clone report JSON parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+0.7.4 (unreleased)
+------------------
+
+* Bugfix: Encode cloned report parameters in the results page URL so values containing `#` are preserved. (#210)
+
 0.7.3 (2026-05-20)
 ------------------
 

--- a/notebooker/web/routes/serve_results.py
+++ b/notebooker/web/routes/serve_results.py
@@ -2,6 +2,7 @@ import json
 import os
 from logging import getLogger
 from typing import Any, Union
+from urllib.parse import urlencode
 
 from flask import Blueprint, Response, abort, render_template, request, url_for, jsonify, current_app
 
@@ -57,7 +58,7 @@ def _render_results(job_id: str, report_name: str, result: NotebookResultBase) -
                 )
 
         if result and result.overrides and urls["clone_url"]:
-            urls["clone_url"] = urls["clone_url"] + "?json_params={}".format(json.dumps(result.overrides))
+            urls["clone_url"] = urls["clone_url"] + "?" + urlencode({"json_params": json.dumps(result.overrides)})
         return render_template(
             "results.html",
             job_id=job_id,

--- a/tests/integration/web/routes/test_serve_results.py
+++ b/tests/integration/web/routes/test_serve_results.py
@@ -1,0 +1,40 @@
+import datetime
+import json
+import re
+from unittest import mock
+from urllib.parse import parse_qs, urlsplit
+
+from notebooker.constants import JobStatus, NotebookResultComplete
+from notebooker.settings import WebappConfig
+from notebooker.web.app import create_app
+from notebooker.web.routes.serve_results import _render_results
+
+
+def test_clone_url_encodes_hash_in_json_parameters():
+    app = create_app(WebappConfig(DISABLE_SCHEDULER=True))
+    app.config.update(
+        DEFAULT_MAILFROM="",
+        DISABLE_SCHEDULER=True,
+        READONLY_MODE=False,
+    )
+    result = NotebookResultComplete(
+        job_id="job1",
+        report_name="report_name",
+        report_title="Report Name",
+        job_start_time=datetime.datetime(2020, 1, 1),
+        job_finish_time=datetime.datetime(2020, 1, 1, 1),
+        raw_html_resources={},
+        raw_html="",
+        status=JobStatus.DONE,
+        overrides={"slack_channel": "#my-fab-channel"},
+    )
+
+    with app.test_request_context():
+        with mock.patch("notebooker.web.routes.serve_results.get_all_possible_templates", return_value={}):
+            rv = _render_results("job1", "report_name", result)
+
+    clone_url_match = re.search(r"cloneReport\('([^']+)'\)", rv)
+    assert clone_url_match is not None
+    clone_url = clone_url_match.group(1)
+    assert urlsplit(clone_url).fragment == ""
+    assert json.loads(parse_qs(urlsplit(clone_url).query)["json_params"][0]) == result.overrides


### PR DESCRIPTION
## Summary

Fixes cloning report parameters when a saved parameter value contains URL-reserved characters such as `#`.

Closes #210.

## Root cause

The results page built the clone URL by appending raw `json.dumps(result.overrides)` directly to the query string:

```python
?json_params={...}
```

When a value contains `#`, browsers interpret the rest of the URL as a fragment instead of part of the query string. That means the server receives truncated JSON when the user clicks **Clone Parameters**, which can lead to a 500 while rendering the run report page.

## Changes

- Encode the `json_params` query value with `urllib.parse.urlencode` before adding it to the clone URL.
- Add a regression test that renders a results page for overrides containing `#my-fab-channel`, extracts the clone URL, and verifies:
  - the URL has no fragment
  - the `json_params` query value round-trips back to the original overrides
- Add a changelog entry for the bugfix.

## Validation

Passed:

```bash
python -m pytest tests/integration/web/routes/test_serve_results.py -q
black --check -l 120 notebooker tests
flake8 notebooker tests
```

Note: I also ran `mypy notebooker tests`. It currently reports existing project-wide type/stub issues unrelated to this focused URL-encoding change.
