### PR TITLE
Encode clone report JSON parameters

### DIFF
--- a/notebooker/web/routes/serve_results.py
+++ b/notebooker/web/routes/serve_results.py
@@ -1,5 +1,6 @@
 import json
 import os
+import urllib.parse
 from logging import getLogger
 from typing import Any, Union
 
@@ -24,6 +25,10 @@ logger = getLogger(__name__)
 
 
 # ------------------- Serving results -------------------- #
+
+
+def _clone_url_with_overrides(clone_url: str, overrides: dict) -> str:
+    return "{}?{}".format(clone_url, urllib.parse.urlencode({"json_params": json.dumps(overrides)}))
 
 
 def _render_results(job_id: str, report_name: str, result: NotebookResultBase) -> str:
@@ -57,7 +62,7 @@ def _render_results(job_id: str, report_name: str, result: NotebookResultBase) -
                 )
 
         if result and result.overrides and urls["clone_url"]:
-            urls["clone_url"] = urls["clone_url"] + "?json_params={}".format(json.dumps(result.overrides))
+            urls["clone_url"] = _clone_url_with_overrides(urls["clone_url"], result.overrides)
         return render_template(
             "results.html",
             job_id=job_id,

--- a/tests/unit/test_serve_results.py
+++ b/tests/unit/test_serve_results.py
@@ -1,0 +1,14 @@
+import json
+import urllib.parse
+
+from notebooker.web.routes.serve_results import _clone_url_with_overrides
+
+
+def test_clone_url_with_overrides_encodes_hash_in_json_params():
+    overrides = {"slack_channel": "#my-fab-channel"}
+    clone_url = _clone_url_with_overrides("/run_report/report_name", overrides)
+    parsed = urllib.parse.urlparse(clone_url)
+
+    assert parsed.fragment == ""
+    assert "%23my-fab-channel" in clone_url
+    assert json.loads(urllib.parse.parse_qs(parsed.query)["json_params"][0]) == overrides


### PR DESCRIPTION
## Summary
- encode clone-report `json_params` with `urlencode` before putting overrides into the query string
- add a unit regression for values containing `#`, so the browser does not treat part of the JSON as a URL fragment

Fixes #210

## Tests
- .venv/bin/python -m pytest tests/unit/test_serve_results.py -q
- .venv/bin/python -m black --check -l 120 notebooker/web/routes/serve_results.py tests/unit/test_serve_results.py
- .venv/bin/python -m flake8 notebooker/web/routes/serve_results.py tests/unit/test_serve_results.py
- .venv/bin/python -m compileall -q notebooker/web/routes/serve_results.py tests/unit/test_serve_results.py

## Local limitation
- .venv/bin/python -m pytest tests/integration/web/test_run_report.py -q cannot run in this local environment because `mongod` is not installed.