### PR TITLE
Apply configured notebook kernel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+0.8.2 (unreleased)
+------------------
+
+* bugfix: apply `--notebook-kernel-name` to generated notebook metadata and invalidate cached templates when the configured kernel changes. (#182)
+
 0.8.1 (2026-06-05)
 ------------------
 

--- a/notebooker/constants.py
+++ b/notebooker/constants.py
@@ -25,11 +25,12 @@ DEFAULT_MONGO_HOST = "localhost"
 DEFAULT_MAILFROM_ADDRESS = "notebooker@localhost"
 
 
-def kernel_spec():
+def kernel_spec(kernel_name: Optional[str] = None):
+    kernel_name = kernel_name or os.getenv("NOTEBOOK_KERNEL_NAME", "notebooker_kernel")
     return {
-        "display_name": os.getenv("NOTEBOOK_KERNEL_NAME", "notebooker_kernel"),
+        "display_name": kernel_name,
         "language": "python",
-        "name": os.getenv("NOTEBOOK_KERNEL_NAME", "notebooker_kernel"),
+        "name": kernel_name,
     }
 
 

--- a/notebooker/execute_notebook.py
+++ b/notebooker/execute_notebook.py
@@ -51,6 +51,7 @@ def _run_checks(
     execute_at_origin: bool = False,
     py_template_base_dir: str = "",
     py_template_subdir: str = "",
+    notebook_kernel_name: Optional[str] = None,
     scheduler_job_id: Optional[str] = None,
     mailfrom: Optional[str] = None,
     is_slideshow: bool = False,
@@ -87,6 +88,8 @@ def _run_checks(
         Whether to disable git pulling of the notebook templates.
     execute_at_origin : `bool`
         Whether to execute the notebook at the original path of the template notebook.
+    notebook_kernel_name : `Optional[str]`
+        The kernel name to write to generated notebook metadata.
     scheduler_job_id : `Optional[str]`
         If available, it will be part of the Error or Completed run report.
     mailfrom : `Optional[str]`
@@ -112,7 +115,13 @@ def _run_checks(
         os.makedirs(output_dir)
 
     py_template_dir = python_template_dir(py_template_base_dir, py_template_subdir)
-    ipynb_raw_path = generate_ipynb_from_py(template_base_dir, template_name, notebooker_disable_git, py_template_dir)
+    ipynb_raw_path = generate_ipynb_from_py(
+        template_base_dir,
+        template_name,
+        notebooker_disable_git,
+        py_template_dir,
+        notebook_kernel_name=notebook_kernel_name,
+    )
     ipynb_executed_path = os.path.join(output_dir, output_ipynb)
 
     logger.info("Executing notebook at {} using parameters {} --> {}".format(ipynb_raw_path, overrides, output_ipynb))
@@ -181,6 +190,7 @@ def run_report(
     execute_at_origin=False,
     py_template_base_dir="",
     py_template_subdir="",
+    notebook_kernel_name=None,
     scheduler_job_id=None,
     mailfrom=None,
     is_slideshow=False,
@@ -219,6 +229,7 @@ def run_report(
             execute_at_origin=execute_at_origin,
             py_template_base_dir=py_template_base_dir,
             py_template_subdir=py_template_subdir,
+            notebook_kernel_name=notebook_kernel_name,
             scheduler_job_id=scheduler_job_id,
             mailfrom=mailfrom,
             is_slideshow=is_slideshow,
@@ -273,6 +284,7 @@ def run_report(
                 notebooker_disable_git=notebooker_disable_git,
                 py_template_base_dir=py_template_base_dir,
                 py_template_subdir=py_template_subdir,
+                notebook_kernel_name=notebook_kernel_name,
                 scheduler_job_id=scheduler_job_id,
                 mailfrom=mailfrom,
                 is_slideshow=is_slideshow,
@@ -397,6 +409,7 @@ def execute_notebook_entrypoint(
     logger.info("execute_at_origin = %s", execute_at_origin)
     logger.info("py_template_base_dir = %s", py_template_base_dir)
     logger.info("py_template_subdir = %s", py_template_subdir)
+    logger.info("notebook_kernel_name = %s", config.NOTEBOOK_KERNEL_NAME)
     logger.info("serializer_cls = %s", config.SERIALIZER_CLS)
     logger.info("serializer_config = %s", config.SERIALIZER_CONFIG)
 
@@ -424,6 +437,7 @@ def execute_notebook_entrypoint(
             execute_at_origin=execute_at_origin,
             py_template_base_dir=py_template_base_dir,
             py_template_subdir=py_template_subdir,
+            notebook_kernel_name=config.NOTEBOOK_KERNEL_NAME,
             scheduler_job_id=scheduler_job_id,
             mailfrom=mailfrom,
             is_slideshow=is_slideshow,
@@ -553,6 +567,7 @@ def run_report_in_subprocess(
         ]
         + (["--notebooker-disable-git"] if base_config.NOTEBOOKER_DISABLE_GIT else [])
         + (["--execute-at-origin"] if base_config.EXECUTE_AT_ORIGIN else [])
+        + (["--notebook-kernel-name", base_config.NOTEBOOK_KERNEL_NAME] if base_config.NOTEBOOK_KERNEL_NAME else [])
         + ["--serializer-cls", result_serializer.__class__.__name__]
         + result_serializer.serializer_args_to_cmdline_args()
         + [

--- a/notebooker/utils/conversion.py
+++ b/notebooker/utils/conversion.py
@@ -1,3 +1,4 @@
+import json
 import os
 import uuid
 from typing import Any, AnyStr, Dict, Optional
@@ -137,6 +138,7 @@ def generate_ipynb_from_py(
     notebooker_disable_git: bool,
     py_template_dir: str,
     warn_on_local: Optional[bool] = True,
+    notebook_kernel_name: Optional[str] = None,
 ) -> str:
     """
     This method EITHER:
@@ -151,6 +153,7 @@ def generate_ipynb_from_py(
     :param notebooker_disable_git: Whether or not to pull the latest version from git, if a change is available.
     :param py_template_dir: The directory which contains raw py/ipynb templates. This should be a subdir in a git repo.
     :param warn_on_local: Whether to warn when we are searching for notebooks in the notebooker repo itself.
+    :param notebook_kernel_name: The kernel name to write to the generated notebook metadata.
 
     :return: The filepath of the .ipynb which we have just converted.
     """
@@ -162,12 +165,16 @@ def generate_ipynb_from_py(
 
     mkdir_p(os.path.dirname(output_template_path))
 
+    requested_kernel_spec = kernel_spec(notebook_kernel_name)
+
     try:
         with open(output_template_path, "r") as f:
-            if f.read():
+            cached_notebook = f.read()
+            cached_kernel_spec = json.loads(cached_notebook).get("metadata", {}).get("kernelspec", {})
+            if cached_notebook and cached_kernel_spec == requested_kernel_spec:
                 print("Loading ipynb from cached location: %s", output_template_path)
                 return output_template_path
-    except IOError:
+    except (IOError, ValueError):
         pass
 
     # "touch" the output file
@@ -176,7 +183,7 @@ def generate_ipynb_from_py(
         os.utime(output_template_path, None)
 
     jupytext_nb = jupytext.read(template_path)
-    jupytext_nb["metadata"]["kernelspec"] = kernel_spec()  # Override the kernel spec since we want to run it..
+    jupytext_nb["metadata"]["kernelspec"] = requested_kernel_spec  # Override the kernel used to run the notebook.
     jupytext.write(jupytext_nb, output_template_path)
 
     return output_template_path

--- a/tests/unit/test_run_report.py
+++ b/tests/unit/test_run_report.py
@@ -6,7 +6,8 @@ from werkzeug.datastructures import CombinedMultiDict, ImmutableMultiDict
 
 from notebooker.constants import DEFAULT_SERIALIZER
 from notebooker.web.routes.report_execution import validate_run_params, RunReportParams
-from notebooker.execute_notebook import _monitor_stderr
+from notebooker.execute_notebook import _monitor_stderr, run_report_in_subprocess
+from notebooker.settings import BaseConfig
 
 
 def test_monitor_stderr():
@@ -70,3 +71,30 @@ def test_validate_run_params():
     actual_output = validate_run_params("lovely_report_name", input_params, issues)
     assert issues == []
     assert actual_output == expected_output
+
+
+def test_run_report_in_subprocess_passes_kernel_name():
+    config = BaseConfig(
+        NOTEBOOK_KERNEL_NAME="python3",
+        OUTPUT_DIR="/tmp/output",
+        TEMPLATE_DIR="/tmp/templates",
+        PY_TEMPLATE_BASE_DIR="/tmp/source",
+        PY_TEMPLATE_SUBDIR="reports",
+        SERIALIZER_CONFIG={},
+    )
+    serializer = mock.Mock()
+    serializer.serializer_args_to_cmdline_args.return_value = []
+    process = mock.Mock(returncode=0)
+
+    with mock.patch(
+        "notebooker.execute_notebook.initialize_serializer_from_config", return_value=serializer
+    ), mock.patch("notebooker.execute_notebook.subprocess.Popen", return_value=process) as popen, mock.patch(
+        "notebooker.execute_notebook.threading.Thread"
+    ), mock.patch(
+        "notebooker.execute_notebook.time.sleep"
+    ):
+        run_report_in_subprocess(config, "report", "Report", "", "", {}, run_synchronously=True)
+
+    command = popen.call_args.args[0]
+    kernel_option_index = command.index("--notebook-kernel-name")
+    assert command[kernel_option_index + 1] == "python3"

--- a/tests/unit/utils/test_conversion.py
+++ b/tests/unit/utils/test_conversion.py
@@ -63,3 +63,36 @@ def test_generate_py_from_ipynb():
     finally:
         shutil.rmtree(ipynb_dir)
         shutil.rmtree(py_dir)
+
+
+def test_generate_ipynb_uses_configured_kernel_and_invalidates_cache(tmp_path):
+    template_dir = tmp_path / "templates"
+    output_dir = tmp_path / "output"
+    template_dir.mkdir()
+    output_dir.mkdir()
+    (template_dir / "report.py").write_text("# %%\nprint('hello')\n")
+
+    with mock.patch("notebooker.utils.conversion._get_output_path_hex", return_value="cached"):
+        first_path = conversion.generate_ipynb_from_py(
+            str(output_dir),
+            "report",
+            notebooker_disable_git=True,
+            py_template_dir=str(template_dir),
+            notebook_kernel_name="python3",
+        )
+        second_path = conversion.generate_ipynb_from_py(
+            str(output_dir),
+            "report",
+            notebooker_disable_git=True,
+            py_template_dir=str(template_dir),
+            notebook_kernel_name="analytics-kernel",
+        )
+
+    assert first_path == second_path
+    with open(second_path) as notebook_file:
+        kernelspec = json.load(notebook_file)["metadata"]["kernelspec"]
+    assert kernelspec == {
+        "display_name": "analytics-kernel",
+        "language": "python",
+        "name": "analytics-kernel",
+    }


### PR DESCRIPTION
## Summary

Fixes `--notebook-kernel-name` so the selected kernel is written to generated notebook metadata in CLI, web-app, and scheduler execution paths.

Closes #182.

## Root cause

The CLI stored the option on `BaseConfig`, but notebook conversion read only the `NOTEBOOK_KERNEL_NAME` environment variable. The web-app subprocess command also omitted the configured kernel. In addition, converted templates are cached by source commit, so an existing cached notebook could retain an earlier kernelspec after the setting changed.

## Changes

- Pass the configured kernel through subprocess, report, and conversion boundaries.
- Let `kernel_spec` accept an explicit kernel while retaining the environment-variable fallback.
- Rebuild a cached converted template when its kernelspec does not match the requested kernel.
- Add regression coverage for both subprocess propagation and cache invalidation.
- Add the required changelog entry.

## Validation

Passed in the repository's Python 3.11 environment:

```bash
black --check -l 120 notebooker tests
flake8 notebooker tests
pytest -q tests/unit/utils/test_conversion.py tests/unit/test_run_report.py
```

The two affected test modules pass: 5 tests passed. The full Mongo-backed integration suite and interactive web app were not run locally.
