### PR TITLE
fix: drop show_link from the plotly example, it blocks test collection

### DIFF
--- a/notebooker/notebook_templates_example/sample/test_plotly.py
+++ b/notebooker/notebook_templates_example/sample/test_plotly.py
@@ -29,6 +29,5 @@ iplot(
         go.Histogram2dContour(x=x, y=y, contours=dict(coloring="heatmap")),
         go.Scatter(x=x, y=y, mode="markers", marker=dict(color="white", size=3, opacity=0.3)),
     ],
-    show_link=False,
     image_width=100,
 )


### PR DESCRIPTION
### The problem

plotly removed `show_link` from `plotly.offline.iplot`. `notebooker/notebook_templates_example/sample/test_plotly.py` still passes it:

```python
iplot(
    [...],
    show_link=False,
    image_width=100,
)
```

so importing the module raises:

```
TypeError: iplot() got an unexpected keyword argument 'show_link'
```

This happens at **collection**, so pytest aborts the entire run and no tests execute:

```
collected 221 items / 1 error
ERROR notebooker/notebook_templates_example/sample/test_plotly.py
!!!!!!!! Interrupted: 1 error during collection !!!!!!!!
Exited with code exit status 2
```

`build_3_8` and `build_3_11` both die here on current PRs. `build_3_6` and `build_3_7` pass because they resolve an older plotly.

### The fix

Drop the argument. `image_width`, the other keyword on the same call, is still supported.

Verified against plotly 7.0.0:

```
=== BEFORE (master) ===
  TypeError: iplot() got an unexpected keyword argument 'show_link'
=== AFTER (show_link removed) ===
  imported OK
```

`show_link` appears nowhere else in the repo, and there is no plotly pin in `setup.py`, `requirements*.txt` or the CircleCI config, so newer plotly is resolved freely.

Kept deliberately minimal, one line. If you would rather pin plotly instead, say so and I will redo it that way.

### Note

I hit this on #221. That PR's test changes have not actually been exercised on 3.8 or 3.11 yet, since collection aborts before anything runs. Merging this first would unblock CI there.
